### PR TITLE
Fix error: TypeError: service.configs is not iterable

### DIFF
--- a/stack.js
+++ b/stack.js
@@ -477,7 +477,7 @@ class dspp {
         delete stack.configs[config_name];
         stack.configs[`${this.stack_name}_${config_name}`] = { external : true};
         for(let [, service] of Object.entries(stack.services)) {
-          for(let config of service.configs) {
+          for(let config of service.configs || []) {
             if(config.source == config_name)
               config.source = `${this.stack_name}_${config_name}`;
           }


### PR DESCRIPTION
Pas certain de comment reproduire, mais observé en local sur un projet avec 500+ configs avec dspp v6.6.2 : 
```
Confirm [y/N/q] (q : toggle diff style): y
Approved
╔══════════════════════════════════════════ Response ══════════════════════════════════════════╗
║{                                                                                             ║
║  "stack_revision": "14c24"                                                                   ║
║}                                                                                             ║
╚══════════════════════════════════════════════════════════════════════════════════════════════╝
$dspp : apply

╔═════════════════════════════════ !! Uncatched exception !! ══════════════════════════════════╗
║TypeError: service.configs is not iterable                                                    ║
╠═══════════════════════════════════════════ Trace ════════════════════════════════════════════╣
║TypeError: service.configs is not iterable                                                    ║
║    at dspp.apply (/usr/lib/node_modules/dspp/stack.js:480:37)                                ║
║    at processTicksAndRejections (node:internal/process/task_queues:96:5)                     ║
║    at async Cnyks.command_loop (/usr/lib/node_modules/dspp/node_modules/cnyks/lib/index.js:3…║
║    at async Cnyks._run (/usr/lib/node_modules/dspp/node_modules/cnyks/lib/index.js:325:5)    ║
╚══════════════════════════════════════════════════════════════════════════════════════════════╝
```